### PR TITLE
Un-escape single quotes

### DIFF
--- a/templates/git2s3.template
+++ b/templates/git2s3.template
@@ -1244,7 +1244,7 @@
                                                         "Ref": "CreateSSHKey"
                                                     },
                                                     "\",\n",
-                                                    "    \"raw-body\" : \"$util.escapeJavaScript($input.body)\"\n",
+                                                    "    \"raw-body\" : \"$util.escapeJavaScript($input.body).replace(\"\\'\",\"'\")\"\n",
                                                     "    }\n",
                                                     "}"
                                                 ]


### PR DESCRIPTION
This resolves an issue where invalid single quote escaping causes failure when a commit message contains a single quote. Single quotes should not be escaped in JSON.

When this error occurs, the response from the POST from github is:

{"message": "Could not parse request body into json: Unrecognized character escape ''' (code 39)...

The fix is described in the AWS reference for $util.escapeJavaScript() here:
http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html