### PR TITLE
Allow whitelist of branches to push to s3

### DIFF
--- a/ci/defaults.json
+++ b/ci/defaults.json
@@ -9,6 +9,10 @@
     },
     {
         "ParameterValue": "",
+        "ParameterKey": "BranchFilterList"
+    },
+    {
+        "ParameterValue": "",
         "ParameterKey": "GitToken"
     },
     {

--- a/lambdas/GitPullS3/lambda_function.py
+++ b/lambdas/GitPullS3/lambda_function.py
@@ -122,6 +122,7 @@ def lambda_handler(event, context):
     keybucket = event['context']['key-bucket']
     outputbucket = event['context']['output-bucket']
     pubkey = event['context']['public-key']
+    branchfilter = event['context']['branch-filter']
     # Source IP ranges to allow requests from, if the IP is in one of these the request will not be chacked for an api key
     ipranges = []
     for i in event['context']['allowed-ips'].split(','):
@@ -163,6 +164,11 @@ def lambda_handler(event, context):
         except:
             branch_name = event['body-json']['ref'].replace('refs/heads/', '')
             repo_name = event['body-json']['repository']['full_name'] + '/branch/' + branch_name
+        if len(branchfilter) > 0:
+            branches = branchfilter.split(":")
+            if branch_name not in branches:
+                logger.info('Branch %s not in filter criteria, exiting...' % branch_name)
+                return 'Branch %s skipped due to filter criteria' % branch_name
     try:
         remote_url = event['body-json']['project']['git_ssh_url']
     except Exception:

--- a/templates/git2s3.template
+++ b/templates/git2s3.template
@@ -19,7 +19,8 @@
                     },
                     "Parameters": [
                         "ApiSecret",
-                        "AllowedIps"
+                        "AllowedIps",
+                        "BranchFilterList"
                     ]
                 },
                 {
@@ -48,6 +49,9 @@
                 },
                 "ApiSecret": {
                     "default": "API Secret"
+                },
+                "BranchFilterList": {
+                    "default": "Branches to Pull"
                 },
                 "CustomDomainName": {
                     "default": "Custom Domain Name"
@@ -84,6 +88,11 @@
             "Type": "String",
             "Default": "",
             "NoEcho": "true"
+        },
+        "BranchFilterList": {
+            "Description": "gitpull method only. Colon (:) delimited list of branches to respond to webhooks for. Notifications about branches not in list will succeed without being saved to s3. Leave blank to pull all branches.",
+            "Type": "String",
+            "Default": ""
         },
         "CustomDomainName": {
             "Description": "Use a custom domain name for the webhook endpoint, if left blank API Gateway will create a domain name for you",
@@ -149,6 +158,18 @@
                     "Fn::Equals": [
                         {
                             "Ref": "ApiSecret"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseBranchFilterList": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "BranchFilterList"
                         },
                         ""
                     ]
@@ -1239,6 +1260,7 @@
                                                     },
                                                     "\",\n",
                                                     "    \"output-bucket\" : \"$stageVariables.outputbucket\",\n",
+                                                    "    \"branch-filter\" : \"$stageVariables.branchfilterlist\",\n",
                                                     "    \"public-key\" : \"",
                                                     {
                                                         "Ref": "CreateSSHKey"
@@ -1421,6 +1443,17 @@
                             "UseApiSecret",
                             {
                                 "Ref": "ApiSecret"
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    "branchfilterlist": {
+                        "Fn::If": [
+                            "UseBranchFilterList",
+                            {
+                                "Ref": "BranchFilterList"
                             },
                             {
                                 "Ref": "AWS::NoValue"


### PR DESCRIPTION
One more if you are interested in including it.. I didn't need all of my feature branches to get pushed to s3 so I added an optional whitelist parameter. If filter is non empty, branches not matching are skipped. Had to use colon as a delimiter as comma is valid in git branch names. Thanks!