### PR TITLE
Make exclude_git configurable

### DIFF
--- a/functions/source/GitPullS3/lambda_function.py
+++ b/functions/source/GitPullS3/lambda_function.py
@@ -15,9 +15,10 @@ from ipaddress import ip_network, ip_address
 import logging
 import hmac
 import hashlib
+import distutils.util
 
 # If true the function will not include .git folder in the zip
-exclude_git = True
+exclude_git = bool(distutils.util.strtobool(os.environ['ExcludeGit']))
 
 # If true the function will delete all files at the end of each invocation, useful if you run into storage space
 # constraints, but will slow down invocations as each invoke will need to checkout the entire repo

--- a/templates/git2s3.template
+++ b/templates/git2s3.template
@@ -905,6 +905,10 @@
                 },
                 "Runtime": "python2.7",
                 "Timeout": "300",
+                "Environment": {
+                    "Variables": 
+                        { "ExcludeGit":"True" }
+                },
                 "Code": {
                     "S3Bucket": {
                         "Ref": "LambdaZipsBucket"


### PR DESCRIPTION
Make exclude_git configurable.  Create an environment variable to decide if the .git directory should be removed prior to zipping the repo contents.  The new environment variable is ExcludeGit.