### PR TITLE
Support branches and tags

### DIFF
--- a/functions/source/GitPullS3/lambda_function.py
+++ b/functions/source/GitPullS3/lambda_function.py
@@ -155,7 +155,10 @@ def lambda_handler(event, context):
         try:
             full_name = event['body-json']['repository']['fullName']
         except KeyError:
-            full_name = event['body-json']['repository']['path_with_namespace']
+            try:
+                full_name = event['body-json']['repository']['path_with_namespace']
+            except KeyError:
+                full_name = event['body-json']['project']['path_with_namespace']
     if not secure:
         logger.error('Source IP %s is not allowed' % event['context']['source-ip'])
         raise Exception('Source IP %s is not allowed' % event['context']['source-ip'])


### PR DESCRIPTION
Allow to fetch source from branch or tag where they were pushed using "ref" attribute in web hook.
Branch mask may later be configured. In our case webhook on git tag event sufficiently limits what needs to be cloned into S3.

Supersedes #22 