### PR TITLE
Using Python 2 string formatting

### DIFF
--- a/functions/source/ZipDl/lambda_function.py
+++ b/functions/source/ZipDl/lambda_function.py
@@ -95,7 +95,7 @@ def lambda_handler(event, context):
         archive_root = event['body-json']['project']['http_url'].strip('.git')
         project_id = event['body-json']['project_id']
         branch = event['body-json']['ref'].replace('refs/heads/', '')
-        archive_url = f"https://gitlab.com/api/v4/projects/{project_id}/repository/archive.zip"
+        archive_url = "https://gitlab.com/api/v4/projects/{}/repository/archive.zip".format(project_id)
         params = {'private_token': OAUTH_token, 'sha': branch}
 
         owner = event['body-json']['project']['namespace']


### PR DESCRIPTION
As part of https://github.com/aws-quickstart/quickstart-git2s3/pull/33, a Python 3 only string formatting mechanism was introduced (https://realpython.com/python-f-strings/) but the CFN template is still using python2.7 as runtime for the lambdas hence a SyntaxError is happening

*Issue #, if available:*

*Description of changes:* 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
