### PR TITLE
Remove redundant check for Gitlab token

### DIFF
--- a/functions/source/GitPullS3/lambda_function.py
+++ b/functions/source/GitPullS3/lambda_function.py
@@ -134,9 +134,6 @@ def lambda_handler(event, context):
     for net in ipranges:
         if ip in net:
             secure = True
-    if 'X-Gitlab-Token' in event['params']['header'].keys():
-        if event['params']['header']['X-Gitlab-Token'] in apikeys:
-            secure = True
     if 'X-Git-Token' in event['params']['header'].keys():
         if event['params']['header']['X-Git-Token'] in apikeys:
             secure = True


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Remove extra check for a Gitlab token in the lambda_handler for GitPullS3. (Duplicate of lines 143-145)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
