### PR TITLE
Add support for bitbucket server 6.6.2

### DIFF
--- a/functions/source/GitPullS3/lambda_function.py
+++ b/functions/source/GitPullS3/lambda_function.py
@@ -191,7 +191,11 @@ def lambda_handler(event, context):
                 # Bibucket server
                 branch_name = event['body-json']['push']['changes'][0]['new']['name']
             except:
-                branch_name = 'master'
+                # Bitbucket Server v6.6.1
+                try:
+                    branch_name = event['body-json']['changes'][0]['ref']['displayId']
+                except:
+                    branch_name = 'master'
     try:
         # GitLab
         remote_url = event['body-json']['project']['git_ssh_url']


### PR DESCRIPTION
*Issue #, if available:* 
JSON format of webhook of bitbucket server 6.6.2 is not supported and slighly different than normal Bitbucket.

*Description of changes:* 
Added support for bitbucket server 6.6.2 as the json is slighly different and the branch name is in a different path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Sample json that bitbucket server 6.6.2 sends as hook
```
{
   "eventKey":"repo:refs_changed",
   "date":"2020-01-14T16:30:45+0100",
   "actor":{
      "name":"****",
      "emailAddress":"****",
      "id":8361,
      "displayName":"****",
      "active":true,
      "slug":"****",
      "type":"NORMAL",
      "links":{
         "self":[
            {
               "href":"****"
            }
         ]
      }
   },
   "repository":{
      "slug":"****",
      "id":2659,
      "name":"****",
      "scmId":"git",
      "state":"AVAILABLE",
      "statusMessage":"Available",
      "forkable":false,
      "project":{
         "key":"****",
         "id":2264,
         "name":"****",
         "description":"****",
         "public":false,
         "type":"NORMAL",
         "links":{
            "self":[
               {
                  "href":"****"
               }
            ]
         }
      },
      "public":false,
      "links":{
         "clone":[
            {
               "href":"****.git",
               "name":"http"
            },
            {
               "href":"ssh://git@****.git",
               "name":"ssh"
            }
         ],
         "self":[
            {
               "href":"https://****/browse"
            }
         ]
      }
   },
   "changes":[
      {
         "ref":{
            "id":"refs/heads/hotfix/transfer-should-be-checked",
            "displayId":"hotfix/transfer-should-be-checked",
            "type":"BRANCH"
         },
         "refId":"refs/heads/hotfix/transfer-should-be-checked",
         "fromHash":"0000000000000000000000000000000000000000",
         "toHash":"4a24622fd85f304770079a8b4dbf9566ea1928c5",
         "type":"ADD"
      }
   ]
}
```