### PR TITLE
Support bitbucket tags on git pull option

### DIFF
--- a/functions/source/GitPullS3/lambda_function.py
+++ b/functions/source/GitPullS3/lambda_function.py
@@ -190,6 +190,8 @@ def lambda_handler(event, context):
             try:
                 # Bibucket server
                 branch_name = event['body-json']['push']['changes'][0]['new']['name']
+                if(event['body-json']['push']['changes'][0]['new']['type'] == 'tag'):
+                    branch_name = 'tags/'+event['body-json']['push']['changes'][0]['new']['name']
             except:
                 branch_name = 'master'
     try:


### PR DESCRIPTION
I found an error when someone push a tag to bitbucket because the path where we execute the pull is incorrect formed like it would be a regular branch.
I added an if checking the type of change that comes in the json form bitbucket, if the type is "tag" I add to the "branch_name" "tags/". This will be used on the pull_repo method to form the reference correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
